### PR TITLE
[NEW] Send Visitor Custom Fields in External Queue Service Call

### DIFF
--- a/app/livechat/server/api/v1/agent.js
+++ b/app/livechat/server/api/v1/agent.js
@@ -4,6 +4,7 @@ import { Match, check } from 'meteor/check';
 import { API } from '../../../../api/server';
 import { findRoom, findGuest, findAgent, findOpenRoom } from '../lib/livechat';
 import { Livechat } from '../../lib/Livechat';
+import { LivechatVisitors } from '../../../../models';
 
 API.v1.addRoute('livechat/agent.info/:rid/:token', {
 	get() {
@@ -60,7 +61,8 @@ API.v1.addRoute('livechat/agent.next/:token', {
 				}
 			}
 
-			const agentData = Promise.await(Livechat.getNextAgent(department));
+			const visitor = LivechatVisitors.getVisitorByToken(token);
+			const agentData = Promise.await(Livechat.getNextAgent(department, undefined, visitor));
 			if (!agentData) {
 				throw new Meteor.Error('agent-not-found');
 			}

--- a/app/livechat/server/lib/Livechat.js
+++ b/app/livechat/server/lib/Livechat.js
@@ -78,8 +78,8 @@ export const Livechat = {
 		return Livechat.checkOnlineAgents(department);
 	},
 
-	getNextAgent(department) {
-		return RoutingManager.getNextAgent(department);
+	getNextAgent(department, ignoreAgentId, visitor) {
+		return RoutingManager.getNextAgent(department, ignoreAgentId, visitor);
 	},
 
 	getAgents(department) {

--- a/app/livechat/server/lib/RoutingManager.js
+++ b/app/livechat/server/lib/RoutingManager.js
@@ -13,7 +13,7 @@ import {
 	allowAgentSkipQueue,
 } from './Helper';
 import { callbacks } from '../../../callbacks/server';
-import { LivechatRooms, Rooms, Messages, Users, LivechatInquiry, Subscriptions } from '../../../models/server';
+import { LivechatRooms, Rooms, Messages, Users, LivechatInquiry, LivechatVisitors, Subscriptions } from '../../../models/server';
 import { Apps, AppEvents } from '../../../apps/server';
 
 export const RoutingManager = {
@@ -39,14 +39,16 @@ export const RoutingManager = {
 		return this.getMethod().config || {};
 	},
 
-	async getNextAgent(department, ignoreAgentId) {
-		return this.getMethod().getNextAgent(department, ignoreAgentId);
+	async getNextAgent(department, ignoreAgentId, visitor) {
+		return this.getMethod().getNextAgent(department, ignoreAgentId, visitor);
 	},
 
 	async delegateInquiry(inquiry, agent, options = {}) {
-		const { department, rid } = inquiry;
+		const { department, rid, v } = inquiry;
+		const visitor = LivechatVisitors.findOneById(v._id);
+
 		if (!agent || (agent.username && !Users.findOneOnlineAgentByUserList(agent.username) && !allowAgentSkipQueue(agent))) {
-			agent = await this.getNextAgent(department);
+			agent = await this.getNextAgent(department, undefined, visitor);
 		}
 
 		if (!agent) {

--- a/app/livechat/server/lib/routing/External.js
+++ b/app/livechat/server/lib/routing/External.js
@@ -18,7 +18,7 @@ class ExternalQueue {
 		};
 	}
 
-	getNextAgent(department, ignoreAgentId) {
+	getNextAgent(department, ignoreAgentId, visitor) {
 		for (let i = 0; i < 10; i++) {
 			try {
 				let queryString = department ? `?departmentId=${ department }` : '';
@@ -26,6 +26,13 @@ class ExternalQueue {
 					const ignoreAgentIdParam = `ignoreAgentId=${ ignoreAgentId }`;
 					queryString = queryString.startsWith('?') ? `${ queryString }&${ ignoreAgentIdParam }` : `?${ ignoreAgentIdParam }`;
 				}
+				const visitorData = visitor && visitor.livechatData;
+
+				if (visitorData && typeof visitorData === 'object') {
+					const customFieldParam = Object.keys(visitorData).map((key) => `${ key }=${ visitorData[key] }`).join('&');
+					queryString = queryString.startsWith('?') ? `${ queryString }&${ customFieldParam }` : `?${ customFieldParam }`;
+				}
+
 				const result = HTTP.call('GET', `${ settings.get('Livechat_External_Queue_URL') }${ queryString }`, {
 					headers: {
 						'User-Agent': 'RocketChat Server',

--- a/app/livechat/server/methods/getNextAgent.js
+++ b/app/livechat/server/methods/getNextAgent.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 
-import { LivechatRooms, Users } from '../../../models';
+import { LivechatRooms, Users, LivechatVisitors } from '../../../models';
 import { Livechat } from '../lib/Livechat';
 
 Meteor.methods({
@@ -21,7 +21,8 @@ Meteor.methods({
 			}
 		}
 
-		const agent = await Livechat.getNextAgent(department);
+		const visitor = LivechatVisitors.getVisitorByToken(token);
+		const agent = await Livechat.getNextAgent(department, undefined, visitor);
 		if (!agent) {
 			return;
 		}


### PR DESCRIPTION
Visitor Custom Fields are passed as query parameters in the URL

i.e, `https://<URL>?customField1=customFieldValue1&customField2=customFieldValue2`